### PR TITLE
Implement request caching

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -521,6 +521,11 @@
         "supports-color": "^5.3.0"
       }
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -1137,9 +1142,9 @@
       }
     },
     "glob": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -1772,6 +1777,14 @@
       "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.1.0.tgz",
       "integrity": "sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q=="
     },
+    "node-cache": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.0.tgz",
+      "integrity": "sha512-gFQwYdoOztBuPlwg6DKQEf50G+gkK69aqLnw4djkmlHCzeVrLJfwvg9xl4RCAGviTIMUVoqcyoZ/V/wPEu/VVg==",
+      "requires": {
+        "clone": "2.x"
+      }
+    },
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
@@ -2014,9 +2027,9 @@
       }
     },
     "resolve": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.13.1.tgz",
+      "integrity": "sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -2241,9 +2254,9 @@
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tslint": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.0.tgz",
-      "integrity": "sha512-2vqIvkMHbnx8acMogAERQ/IuINOq6DFqgF8/VDvhEkBqQh/x6SP0Y+OHnKth9/ZcHQSroOZwUQSN18v8KKF0/g==",
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
+      "integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -27,10 +27,11 @@
     "firebase-admin": "^8.0.0",
     "firebase-functions": "^3.1.0",
     "helmet": "^3.21.1",
-    "morgan": "^1.9.1"
+    "morgan": "^1.9.1",
+    "node-cache": "^5.1.0"
   },
   "devDependencies": {
-    "tslint": "^5.12.0",
+    "tslint": "^5.20.1",
     "typescript": "^3.2.2"
   },
   "private": true

--- a/functions/src/controllers/movies.ts
+++ b/functions/src/controllers/movies.ts
@@ -4,10 +4,10 @@ import { filterOptions } from '../helpers/filter';
 
 export class Movies {
   static getMovies(req: Request, res: Response) {
-    let { params: { type } } = req;
+    const { params: { type } } = req;
     return res.status(200).json({
       status: 'success',
-      data: {
+      result: {
         [type]: type === 'movies'? MovieSeries : TvSeries,
       },
     })

--- a/functions/src/middlewares/cacheMiddleware.ts
+++ b/functions/src/middlewares/cacheMiddleware.ts
@@ -1,0 +1,28 @@
+import NodeCache from 'node-cache';
+import { Request, Response } from 'express';
+
+export const CacheMiddleware = (timeout: number) => {
+  // @ts-ignore
+  return (req: Request, res: Response, next: Function) => {
+    const Cache = new NodeCache({ stdTTL: timeout, checkperiod: timeout * 2, useClones: false })
+    let key =  `cache<=>${req.originalUrl || req.url}`;
+    let cacheContent = Cache.get(key);
+    if(cacheContent) {
+      return res.status(200).json({
+        status: 'Success',
+        result: cacheContent
+      });
+    } else{
+      // @ts-ignore
+      res.sendJson = res.json;
+      // @ts-ignore
+      res.json = ({ status, result, ...rest }) => {
+        console.log(status, rest)
+        Cache.set(key, result, timeout);
+        // @ts-ignore
+        res.sendJson({ status, result, ...rest });
+      }
+      next();
+    }
+  }
+}

--- a/functions/src/middlewares/validation.ts
+++ b/functions/src/middlewares/validation.ts
@@ -44,7 +44,7 @@ const validateParams = (req: Request, res: Response, next: Function) => {
 const queryOptions = ['title', 'year', 'language', 'imdbRating', 'imdbID', 'type'];
 export const filterQuery = (req: Request, res: Response, next: Function) => {
   const filteredQuery: any = {};
-  for (let query in req.query) {
+  for (const query in req.query) {
     const lCased = query.toLowerCase();
     (typeof query) === 'string' && (queryOptions.indexOf(lCased) !== -1) && (filteredQuery[lCased] = req.query[query]);
   }

--- a/functions/src/routes/movies.ts
+++ b/functions/src/routes/movies.ts
@@ -1,14 +1,15 @@
 import * as express from 'express';
 import { Movies } from '../controllers';
 import { validateType, filterQuery } from '../middlewares/validation';
+import { CacheMiddleware } from '../middlewares/cacheMiddleware';
 
 const movies = express.Router();
 const { getMovies, getSingleMovie } = Movies;
 
 movies.route('/media/:type')
-  .get(validateType, getMovies);
+  .get(validateType, CacheMiddleware(10), getMovies);
 
 movies.route('/search')
-  .get(filterQuery, getSingleMovie);
+  .get(filterQuery, CacheMiddleware(10), getSingleMovie);
 
 export default movies;


### PR DESCRIPTION
#### What does this PR do?
This implements the caching of requests on the server to reduce excessive querying of the resources.

#### Description of Task to be completed?
- Installation of the node-cache API.
- Create a caching middleware that responds to a similar request within a timeout record of 10secs from a cache.

#### How should this be manually tested?
- Clone this branch.
- Run cd into `Mini-Netflix-Backend`.
- Run `npm install` to install the dependencies.
- Run `npm test` to run the tests.

#### Any background context you want to provide?

#### What are the relevant pivotal tracker stories? #<insert_id>

Screenshots (if appropriate)

Questions: