### PR TITLE
Implement forking of child clusters

### DIFF
--- a/functions/src/cluster.ts
+++ b/functions/src/cluster.ts
@@ -1,0 +1,11 @@
+import cluster from 'cluster';
+import os from 'os';
+
+if (cluster.isMaster) {
+  const cpus = os.cpus().length;
+  for (let i = 0; i < cpus; i++) {
+    cluster.fork();
+  }
+} else {
+  require('./http');
+}

--- a/functions/src/routes/movies.ts
+++ b/functions/src/routes/movies.ts
@@ -7,9 +7,9 @@ const movies = express.Router();
 const { getMovies, getSingleMovie } = Movies;
 
 movies.route('/media/:type')
-  .get(validateType, CacheMiddleware(10), getMovies);
+  .get(validateType, CacheMiddleware(60), getMovies);
 
 movies.route('/search')
-  .get(filterQuery, CacheMiddleware(10), getSingleMovie);
+  .get(filterQuery, CacheMiddleware(60), getSingleMovie);
 
 export default movies;


### PR DESCRIPTION
#### What does this PR do?
Improves the performance of the application by spawning child cluster to independently handle and balance server load.

#### Description of Task to be completed?
- Import the cluster and os module.
- Implement an algorithm to calculate the total number of CPU cores and spawn clusters for each CPU cores available.

#### How should this be manually tested?
- Clone this branch.
- Run cd into `Mini-Netflix-Backend`.
- Run `npm install` to install the dependencies.
- Run `npm test` to run the tests.

#### Any background context you want to provide?

#### What are the relevant pivotal tracker stories? #<insert_id>

Screenshots (if appropriate)

Questions: